### PR TITLE
Fix duplicate global:: prefix in routed event handler types

### DIFF
--- a/src/libs/DependencyPropertyGenerator/DependencyPropertyGenerator.csproj
+++ b/src/libs/DependencyPropertyGenerator/DependencyPropertyGenerator.csproj
@@ -47,7 +47,7 @@
     
     <ItemGroup Label="Attributes">
         <EmbeddedResource Include="../$(AssemblyName).Attributes/*.cs" Visible="false" />
-        <AdditionalFiles Include="../$(AssemblyName).Attributes/*.cs" Visible="false" />
+        <AdditionalFiles Include="../$(AssemblyName).Attributes/*.cs" Visible="false" HResourcesGenerator_Resource="true" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/libs/DependencyPropertyGenerator/Generators/PrepareData.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/PrepareData.cs
@@ -169,12 +169,12 @@ public static class PrepareData
             .ToEnum(defaultValue: RoutedEventStrategy.Direct)
             .ToString("G");
         var isStatic = attribute.GetNamedArgument(nameof(WeakEventAttribute.IsStatic)).ToBoolean();
-        var type =
-            attribute.GetGenericTypeArgument(0)?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ??
-            attribute.GetNamedArgument(nameof(RoutedEventAttribute.Type)).Value?.ToString() ??
-            string.Empty;
+        var typeSymbol =
+            attribute.GetGenericTypeArgument(0) ??
+            attribute.GetNamedArgument(nameof(RoutedEventAttribute.Type)).Value as ITypeSymbol;
+        var type = typeSymbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty;
         var isValueType =
-            attribute.GetGenericTypeArgument(0)?.IsValueType ??
+            typeSymbol?.IsValueType ??
             attribute.ConstructorArguments.ElementAtOrDefault(1).Type?.IsValueType ??
             true;
         var isAttached = attribute.GetNamedArgument(nameof(RoutedEventAttribute.IsAttached)).ToBoolean();

--- a/src/libs/DependencyPropertyGenerator/Sources/Sources.RoutedEvent.cs
+++ b/src/libs/DependencyPropertyGenerator/Sources/Sources.RoutedEvent.cs
@@ -163,7 +163,7 @@ namespace {@class.Namespace}
             return GenerateRoutedEventHandlerType(@class);
         }
 
-        return @event.Type.WithGlobalPrefix();
+        return @event.Type;
     }
 
     private static string GenerateRoutedEventType(ClassData @class)

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Helpers.cs
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Helpers.cs
@@ -82,13 +82,7 @@ using DependencyPropertyGenerator;
         return globalOptions;
     }
 
-    private async Task CheckSourceAsync<T>(
-        string source,
-        Framework framework,
-        [CallerMemberName] string? callerName = null,
-        CancellationToken cancellationToken = default,
-        params IIncrementalGenerator[] additionalGenerators)
-        where T : IIncrementalGenerator, new()
+    private static string ApplyFrameworkReplacements(string source, Framework framework)
     {
         if (framework == Framework.Wpf)
         {
@@ -140,6 +134,19 @@ using DependencyPropertyGenerator;
             source = @$"using Microsoft.Maui.Controls;
 {source}";
         }
+
+        return source;
+    }
+
+    private async Task CheckSourceAsync<T>(
+        string source,
+        Framework framework,
+        [CallerMemberName] string? callerName = null,
+        CancellationToken cancellationToken = default,
+        params IIncrementalGenerator[] additionalGenerators)
+        where T : IIncrementalGenerator, new()
+    {
+        source = ApplyFrameworkReplacements(source, framework);
 
         var referenceAssemblies = framework switch
         {
@@ -195,6 +202,49 @@ using DependencyPropertyGenerator;
                 .UseDirectory($"Snapshots/{callerName}/{framework:G}")
                 //.AutoVerify()
                 .UseFileName("_"));
+    }
+
+    private static async Task<string> GenerateSourceAsync<T>(
+        string source,
+        Framework framework,
+        CancellationToken cancellationToken = default)
+        where T : IIncrementalGenerator, new()
+    {
+        source = ApplyFrameworkReplacements(source, framework);
+        var referenceAssemblies = framework switch
+        {
+            Framework.None => ReferenceAssemblies.NetFramework.Net48.Wpf,
+            Framework.Wpf => ReferenceAssemblies.NetFramework.Net48.Wpf,
+            Framework.Uwp => FrameworkReferenceAssemblies.Net80Uwp,
+            Framework.WinUi => FrameworkReferenceAssemblies.Net80WinUi,
+            Framework.Uno => FrameworkReferenceAssemblies.Net80Uno,
+            Framework.UnoWinUi => FrameworkReferenceAssemblies.Net80UnoWinUi,
+            Framework.Avalonia => FrameworkReferenceAssemblies.Net60Avalonia,
+            Framework.Maui => FrameworkReferenceAssemblies.Net70Maui,
+            _ => throw new NotImplementedException(),
+        };
+        var references = await referenceAssemblies.ResolveAsync(null, cancellationToken);
+        var compilation = (Compilation)CSharpCompilation.Create(
+            assemblyName: "Tests",
+            syntaxTrees: new[]
+            {
+                CSharpSyntaxTree.ParseText(source, options: new CSharpParseOptions(LanguageVersion.Preview),
+                    cancellationToken: cancellationToken),
+            },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: new[] { new T().AsSourceGenerator() },
+            parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+        driver = driver
+            .WithUpdatedAnalyzerConfigOptions(new DictionaryAnalyzerConfigOptionsProvider(GetGlobalOptions(framework)))
+            .RunGeneratorsAndUpdateCompilation(compilation, out _, out _, cancellationToken);
+
+        return string.Join(
+            Environment.NewLine,
+            driver.GetRunResult().Results
+                .SelectMany(result => result.GeneratedSources)
+                .Select(generatedSource => generatedSource.SourceText.ToString()));
     }
 }
 

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.RoutedEvents.cs
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.RoutedEvents.cs
@@ -31,4 +31,44 @@ public partial class MyControl : UserControl
 {
 }", framework);
     }
+
+    [DataTestMethod]
+    [DataRow(Framework.Wpf)]
+    [DataRow(Framework.Uno)]
+    [DataRow(Framework.UnoWinUi)]
+    [DataRow(Framework.Avalonia)]
+    public async Task RoutedEvent_WithGenericHandlerType_DoesNotProduceDuplicateGlobalPrefix(Framework framework)
+    {
+        var source = GetHeader(framework, "Controls") + @"
+public delegate void MyRoutedEventHandler(object sender, global::System.EventArgs e);
+
+[RoutedEvent<MyRoutedEventHandler>(""TrayLeftMouseDown"", RoutedEventStrategy.Bubble, WinRtEvents = true)]
+public partial class MyControl : UserControl
+{
+}";
+        var generated = await GenerateSourceAsync<RoutedEventGenerator>(source, framework);
+
+        generated.Should().NotContain("global::global::");
+        generated.Should().Contain("global::H.Generators.IntegrationTests.MyRoutedEventHandler");
+    }
+
+    [DataTestMethod]
+    [DataRow(Framework.Wpf)]
+    [DataRow(Framework.Uno)]
+    [DataRow(Framework.UnoWinUi)]
+    [DataRow(Framework.Avalonia)]
+    public async Task RoutedEvent_WithTypeNamedArgument_DoesNotProduceDuplicateGlobalPrefix(Framework framework)
+    {
+        var source = GetHeader(framework, "Controls") + @"
+public delegate void MyRoutedEventHandler(object sender, global::System.EventArgs e);
+
+[RoutedEvent(""TrayLeftMouseDown"", RoutedEventStrategy.Bubble, Type = typeof(MyRoutedEventHandler), WinRtEvents = true)]
+public partial class MyControl : UserControl
+{
+}";
+        var generated = await GenerateSourceAsync<RoutedEventGenerator>(source, framework);
+
+        generated.Should().NotContain("global::global::");
+        generated.Should().Contain("global::H.Generators.IntegrationTests.MyRoutedEventHandler");
+    }
 }


### PR DESCRIPTION
## Summary

Routed event handler types produced by `RoutedEventGenerator` could end up with a duplicated `global::global::` prefix when the handler type came from the generic `RoutedEventAttribute<T>`.

See https://github.com/HavenDV/DependencyPropertyGenerator/issues/70

### Root cause

`PrepareData.GetEventData` read the handler type via two paths:

- Generic `T`: `ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)` — already prefixed with `global::`.
- Named arg `Type = typeof(...)`: `GetNamedArgument("Type").Value?.ToString()` on the `ITypeSymbol` — no prefix.

`Sources.RoutedEvent.GenerateRouterEventType` then unconditionally appended `.WithGlobalPrefix()`, yielding `global::global::Namespace.Handler` for the generic case and the correct `global::Namespace.Handler` for the named case.

### Fix

- Normalize both paths in `GetEventData` by resolving an `ITypeSymbol` first and running it through `FullyQualifiedFormat`, so `EventData.Type` is always `global::`-prefixed.
- Drop the redundant `.WithGlobalPrefix()` call in `GenerateRouterEventType`.

### Tests

Added two `DataTestMethod` cases in `Tests.RoutedEvents.cs` (WPF / Uno / UnoWinUi / Avalonia) that run the generator against a class using the generic `RoutedEventAttribute<T>` and `Type = typeof(...)` named arg respectively, and assert:

- the generated source contains no `global::global::` substring;
- the fully-qualified handler type appears with a single `global::` prefix.

A small `GenerateSourceAsync<T>` helper was extracted alongside the existing `CheckSourceAsync` to support assertion-based (non-snapshot) tests, reusing the same per-framework source replacements.

### Build fix (included)

While working on this, local builds failed with `CS0117: Resources does not contain a definition for <Attribute>_cs` because `H.Resources.Generator` 1.8.0 now requires the `HResourcesGenerator_Resource="true"` metadata on any `AdditionalFiles` entry (release note: *"HResourcesGenerator_Resource="true" is required now for custom resources."*). Added the metadata to the `AdditionalFiles` item in `DependencyPropertyGenerator.csproj`.

## Commits

- `ceb67ca` — fix: avoid duplicate `global::` prefix in generated routed event handler type
- `039566c` — test: cover routed event handler type `global::` prefix
- `06eb251` — build: mark attribute sources as `H.Resources.Generator` resources

## Test plan

- [x] `dotnet build src/libs/DependencyPropertyGenerator/DependencyPropertyGenerator.csproj` → 0 errors
- [x] `dotnet test src/tests/DependencyPropertyGenerator.SnapshotTests --filter "FullyQualifiedName~RoutedEvent"` → 8/8 passed
- [ ] CI green