### PR TITLE
Stabilize diagnostic snapshots

### DIFF
--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner/Avalonia/Tests.AddOwner_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner/Avalonia/Tests.AddOwner_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using Avalonia.Media;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner/Maui/Tests.AddOwner_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner/Maui/Tests.AddOwner_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner2/Avalonia/Tests.AddOwner2_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner2/Avalonia/Tests.AddOwner2_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using Avalonia.Controls;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner2/Maui/Tests.AddOwner2_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AddOwner2/Maui/Tests.AddOwner2_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AttachedPropertyWithoutSecondType/Maui/Tests.AttachedPropertyWithoutSecondType_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/AttachedPropertyWithoutSecondType/Maui/Tests.AttachedPropertyWithoutSecondType_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-*/
- : (0,0)-(0,30),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,31),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Avalonia/Tests.Attributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Avalonia/Tests.Attributes_Diagnostics.verified.txt
@@ -1,21 +1,10 @@
 ﻿[
   {
-    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs: (33,23)-(33,41),
-    Message: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs,
+    Span: (34,24)-(34,42),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Maui/Tests.Attributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Maui/Tests.Attributes_Diagnostics.verified.txt
@@ -1,21 +1,10 @@
 ﻿[
   {
-    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyGrid.Properties.AttributedProperty.g.cs: (37,23)-(37,41),
-    Message: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyGrid.Properties.AttributedProperty.g.cs,
+    Span: (38,24)-(38,42),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Uno/Tests.Attributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Uno/Tests.Attributes_Diagnostics.verified.txt
@@ -1,21 +1,10 @@
 ﻿[
   {
-    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs: (33,23)-(33,41),
-    Message: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs,
+    Span: (34,24)-(34,42),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/UnoWinUi/Tests.Attributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/UnoWinUi/Tests.Attributes_Diagnostics.verified.txt
@@ -1,21 +1,10 @@
 ﻿[
   {
-    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs: (33,23)-(33,41),
-    Message: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs,
+    Span: (34,24)-(34,42),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Wpf/Tests.Attributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Attributes/Wpf/Tests.Attributes_Diagnostics.verified.txt
@@ -1,21 +1,10 @@
 ﻿[
   {
-    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs: (38,23)-(38,41),
-    Message: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.DependencyPropertyGenerator\H.Generators.IntegrationTests.MyControl.Properties.AttributedProperty.g.cs,
+    Span: (39,24)-(39,42),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvent/Avalonia/Tests.BindEvent_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvent/Avalonia/Tests.BindEvent_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using Avalonia.Input;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvent/Maui/Tests.BindEvent_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvent/Maui/Tests.BindEvent_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvents/Avalonia/Tests.BindEvents_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvents/Avalonia/Tests.BindEvents_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using Avalonia.Input;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvents/Maui/Tests.BindEvents_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/BindEvents/Maui/Tests.BindEvents_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/CustomOnChanged/Avalonia/Tests.CustomOnChanged_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/CustomOnChanged/Avalonia/Tests.CustomOnChanged_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/CustomOnChanged/Maui/Tests.CustomOnChanged_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/CustomOnChanged/Maui/Tests.CustomOnChanged_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Dictionary/Avalonia/Tests.Dictionary_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Dictionary/Avalonia/Tests.Dictionary_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Dictionary/Maui/Tests.Dictionary_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Dictionary/Maui/Tests.Dictionary_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Enum/Uno/Tests.Enum_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Enum/Uno/Tests.Enum_Diagnostics.verified.txt
@@ -1,166 +1,64 @@
 ﻿[
   {
-    Location: /*
-{
-    static partial void OnModeChanged(TreeView sender, Mode oldValue, Mode newValue)
-                                      ^^^^^^^^
-    {
-*/
- : (16,38)-(16,46),
-    Message: 'TreeView' is obsolete: 'The Windows.UI.Xaml.Controls version of this control is not supported. Please use Microsoft.UI.Xaml.Controls.TreeView instead.',
+    Id: CS0618,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (17,39)-(17,47),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs: (58,42)-(58,83),
-    Message: '{0}' is obsolete: '{1}',
-    Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
-  },
-  {
-    Location: /*
-
-[AttachedDependencyProperty<Mode, TreeView>("Mode", DefaultValue = Mode.Mode2)]
-                                  ^^^^^^^^
-public static partial class TreeViewExtensions
-*/
- : (13,34)-(13,42),
-    Message: 'TreeView' is obsolete: 'The Windows.UI.Xaml.Controls version of this control is not supported. Please use Microsoft.UI.Xaml.Controls.TreeView instead.',
+    Id: CS0618,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs,
+    Span: (59,43)-(59,84),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs: (32,35)-(32,76),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Span: (14,35)-(14,43),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs: (44,73)-(44,114),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs,
+    Span: (33,36)-(33,77),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs: (54,42)-(54,83),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs,
+    Span: (45,74)-(45,115),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs: (56,42)-(56,83),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs,
+    Span: (55,43)-(55,84),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs: (22,29)-(22,70),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs,
+    Span: (57,43)-(57,84),
+    MessageFormat: '{0}' is obsolete: '{1}'
+  },
+  {
+    Id: CS0618,
+    Severity: Warning,
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.Mode.g.cs,
+    Span: (23,30)-(23,71),
+    MessageFormat: '{0}' is obsolete: '{1}'
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/InheritClass/Avalonia/Tests.InheritClass_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/InheritClass/Avalonia/Tests.InheritClass_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using Avalonia.Controls;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/InheritClass/Maui/Tests.InheritClass_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/InheritClass/Maui/Tests.InheritClass_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultiTypesInOne/Avalonia/Tests.MultiTypesInOne_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultiTypesInOne/Avalonia/Tests.MultiTypesInOne_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultiTypesInOne/Maui/Tests.MultiTypesInOne_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultiTypesInOne/Maui/Tests.MultiTypesInOne_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultidimensionalArray/Avalonia/Tests.MultidimensionalArray_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultidimensionalArray/Avalonia/Tests.MultidimensionalArray_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultidimensionalArray/Maui/Tests.MultidimensionalArray_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/MultidimensionalArray/Maui/Tests.MultidimensionalArray_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableDisable/Avalonia/Tests.NullableDisable_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableDisable/Avalonia/Tests.NullableDisable_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableDisable/Maui/Tests.NullableDisable_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableDisable/Maui/Tests.NullableDisable_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableValueType/Avalonia/Tests.NullableValueType_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableValueType/Avalonia/Tests.NullableValueType_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableValueType/Maui/Tests.NullableValueType_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/NullableValueType/Maui/Tests.NullableValueType_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadata/Avalonia/Tests.OverrideMetadata_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadata/Avalonia/Tests.OverrideMetadata_Diagnostics.verified.txt
@@ -1,51 +1,15 @@
 ﻿[
   {
-    Location: /*
-{
-    partial void OnAquariumGraphicChanged()
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-    {
-*/
- : (18,17)-(18,41),
-    Message: No defining declaration found for implementing declaration of partial method 'TropicalAquarium.OnAquariumGraphicChanged()',
+    Id: CS0759,
     Severity: Error,
-    Descriptor: {
-      Id: CS0759,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0759),
-      MessageFormat: No defining declaration found for implementing declaration of partial method '{0}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
+    Span: (19,18)-(19,42),
+    MessageFormat: No defining declaration found for implementing declaration of partial method '{0}'
   },
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using System;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadata/Maui/Tests.OverrideMetadata_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadata/Maui/Tests.OverrideMetadata_Diagnostics.verified.txt
@@ -1,52 +1,15 @@
 ﻿[
   {
-    Location: /*
-{
-    partial void OnAquariumGraphicChanged()
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-    {
-*/
- : (19,17)-(19,41),
-    Message: No defining declaration found for implementing declaration of partial method 'TropicalAquarium.OnAquariumGraphicChanged()',
+    Id: CS0759,
     Severity: Error,
-    Descriptor: {
-      Id: CS0759,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0759),
-      MessageFormat: No defining declaration found for implementing declaration of partial method '{0}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
+    Span: (20,18)-(20,42),
+    MessageFormat: No defining declaration found for implementing declaration of partial method '{0}'
   },
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using System;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadataForReadOnlyProperty/Avalonia/Tests.OverrideMetadataForReadOnlyProperty_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadataForReadOnlyProperty/Avalonia/Tests.OverrideMetadataForReadOnlyProperty_Diagnostics.verified.txt
@@ -1,51 +1,15 @@
 ﻿[
   {
-    Location: /*
-{
-    partial void OnAquariumGraphicChanged()
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-    {
-*/
- : (18,17)-(18,41),
-    Message: No defining declaration found for implementing declaration of partial method 'TropicalAquarium.OnAquariumGraphicChanged()',
+    Id: CS0759,
     Severity: Error,
-    Descriptor: {
-      Id: CS0759,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0759),
-      MessageFormat: No defining declaration found for implementing declaration of partial method '{0}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
+    Span: (19,18)-(19,42),
+    MessageFormat: No defining declaration found for implementing declaration of partial method '{0}'
   },
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using System;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadataForReadOnlyProperty/Maui/Tests.OverrideMetadataForReadOnlyProperty_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/OverrideMetadataForReadOnlyProperty/Maui/Tests.OverrideMetadataForReadOnlyProperty_Diagnostics.verified.txt
@@ -1,52 +1,15 @@
 ﻿[
   {
-    Location: /*
-{
-    partial void OnAquariumGraphicChanged()
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-    {
-*/
- : (19,17)-(19,41),
-    Message: No defining declaration found for implementing declaration of partial method 'TropicalAquarium.OnAquariumGraphicChanged()',
+    Id: CS0759,
     Severity: Error,
-    Descriptor: {
-      Id: CS0759,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0759),
-      MessageFormat: No defining declaration found for implementing declaration of partial method '{0}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
+    Span: (20,18)-(20,42),
+    MessageFormat: No defining declaration found for implementing declaration of partial method '{0}'
   },
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using System;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/PrimitiveTypeArray/Avalonia/Tests.PrimitiveTypeArray_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/PrimitiveTypeArray/Avalonia/Tests.PrimitiveTypeArray_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/PrimitiveTypeArray/Maui/Tests.PrimitiveTypeArray_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/PrimitiveTypeArray/Maui/Tests.PrimitiveTypeArray_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/ReadmeExample/Uno/Tests.ReadmeExample_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/ReadmeExample/Uno/Tests.ReadmeExample_Diagnostics.verified.txt
@@ -1,166 +1,64 @@
 ﻿[
   {
-    Location: /*
-    // Optional
-    static partial void OnSelectedItemChanged(TreeView sender, object? oldValue, object? newValue)
-                                              ^^^^^^^^
-    {
-*/
- : (20,46)-(20,54),
-    Message: 'TreeView' is obsolete: 'The Windows.UI.Xaml.Controls version of this control is not supported. Please use Microsoft.UI.Xaml.Controls.TreeView instead.',
+    Id: CS0618,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (21,47)-(21,55),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs: (58,50)-(58,91),
-    Message: '{0}' is obsolete: '{1}',
-    Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
-  },
-  {
-    Location: /*
-
-[AttachedDependencyProperty<object, TreeView>("SelectedItem", DefaultBindingMode = DefaultBindingMode.TwoWay)]
-                                    ^^^^^^^^
-public static partial class TreeViewExtensions
-*/
- : (16,36)-(16,44),
-    Message: 'TreeView' is obsolete: 'The Windows.UI.Xaml.Controls version of this control is not supported. Please use Microsoft.UI.Xaml.Controls.TreeView instead.',
+    Id: CS0618,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs,
+    Span: (59,51)-(59,92),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs: (32,43)-(32,84),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Span: (17,37)-(17,45),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs: (44,46)-(44,87),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs,
+    Span: (33,44)-(33,85),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs: (54,50)-(54,91),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs,
+    Span: (45,47)-(45,88),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs: (56,50)-(56,91),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs,
+    Span: (55,51)-(55,92),
+    MessageFormat: '{0}' is obsolete: '{1}'
   },
   {
-    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs: (22,29)-(22,70),
-    Message: '{0}' is obsolete: '{1}',
+    Id: CS0618,
     Severity: Warning,
-    WarningLevel: 1,
-    Descriptor: {
-      Id: CS0618,
-      Title: Type or member is obsolete,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618),
-      MessageFormat: '{0}' is obsolete: '{1}',
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs,
+    Span: (57,51)-(57,92),
+    MessageFormat: '{0}' is obsolete: '{1}'
+  },
+  {
+    Id: CS0618,
+    Severity: Warning,
+    WarningLevel: 2,
+    Location: DependencyPropertyGenerator\H.Generators.AttachedDependencyPropertyGenerator\H.Generators.IntegrationTests.TreeViewExtensions.AttachedProperties.SelectedItem.g.cs,
+    Span: (23,30)-(23,71),
+    MessageFormat: '{0}' is obsolete: '{1}'
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/SameNameDifferentNamespaces/Avalonia/Tests.SameNameDifferentNamespaces_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/SameNameDifferentNamespaces/Avalonia/Tests.SameNameDifferentNamespaces_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/SameNameDifferentNamespaces/Maui/Tests.SameNameDifferentNamespaces_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/SameNameDifferentNamespaces/Maui/Tests.SameNameDifferentNamespaces_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/StaticWeakEventWithType/Wpf/Tests.StaticWeakEventWithType_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/StaticWeakEventWithType/Wpf/Tests.StaticWeakEventWithType_Diagnostics.verified.txt
@@ -1,21 +1,9 @@
 ﻿[
   {
-    Location: DependencyPropertyGenerator\H.Generators.WeakEventGenerator\H.Generators.IntegrationTests.MyControl.WeakEvents.UrlChanged.g.cs: (62,37)-(62,41),
-    Message: Argument {0}: cannot convert from '{1}' to '{2}',
+    Id: CS1503,
     Severity: Error,
-    Descriptor: {
-      Id: CS1503,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS1503),
-      MessageFormat: Argument {0}: cannot convert from '{1}' to '{2}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
+    Location: DependencyPropertyGenerator\H.Generators.WeakEventGenerator\H.Generators.IntegrationTests.MyControl.WeakEvents.UrlChanged.g.cs,
+    Span: (63,38)-(63,42),
+    MessageFormat: Argument {0}: cannot convert from '{1}' to '{2}'
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Tuples/Avalonia/Tests.Tuples_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Tuples/Avalonia/Tests.Tuples_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Tuples/Maui/Tests.Tuples_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/Tuples/Maui/Tests.Tuples_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WeakEventWithType/Wpf/Tests.WeakEventWithType_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WeakEventWithType/Wpf/Tests.WeakEventWithType_Diagnostics.verified.txt
@@ -1,21 +1,9 @@
 ﻿[
   {
-    Location: DependencyPropertyGenerator\H.Generators.WeakEventGenerator\H.Generators.IntegrationTests.MyControl.WeakEvents.UrlChanged.g.cs: (62,37)-(62,41),
-    Message: Argument {0}: cannot convert from '{1}' to '{2}',
+    Id: CS1503,
     Severity: Error,
-    Descriptor: {
-      Id: CS1503,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS1503),
-      MessageFormat: Argument {0}: cannot convert from '{1}' to '{2}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
+    Location: DependencyPropertyGenerator\H.Generators.WeakEventGenerator\H.Generators.IntegrationTests.MyControl.WeakEvents.UrlChanged.g.cs,
+    Span: (63,38)-(63,42),
+    MessageFormat: Argument {0}: cannot convert from '{1}' to '{2}'
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Avalonia/Tests.WithOtherAttributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Avalonia/Tests.WithOtherAttributes_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-[CLSCompliant(false)]
-public partial class MyControl : UserControl
-                     ^^^^^^^^^
-{
-*/
- : (9,21)-(9,30),
-    Message: 'MyControl' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (10,22)-(10,31),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Maui/Tests.WithOtherAttributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Maui/Tests.WithOtherAttributes_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-[CLSCompliant(false)]
-public partial class MyGrid : Grid
-                     ^^^^^^
-{
-*/
- : (10,21)-(10,27),
-    Message: 'MyGrid' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (11,22)-(11,28),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Uno/Tests.WithOtherAttributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Uno/Tests.WithOtherAttributes_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-[CLSCompliant(false)]
-public partial class MyControl : UserControl
-                     ^^^^^^^^^
-{
-*/
- : (9,21)-(9,30),
-    Message: 'MyControl' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (10,22)-(10,31),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/UnoWinUi/Tests.WithOtherAttributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/UnoWinUi/Tests.WithOtherAttributes_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-[CLSCompliant(false)]
-public partial class MyControl : UserControl
-                     ^^^^^^^^^
-{
-*/
- : (9,21)-(9,30),
-    Message: 'MyControl' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (10,22)-(10,31),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Wpf/Tests.WithOtherAttributes_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes/Wpf/Tests.WithOtherAttributes_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-[CLSCompliant(false)]
-public partial class MyControl : UserControl
-                     ^^^^^^^^^
-{
-*/
- : (9,21)-(9,30),
-    Message: 'MyControl' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
+    Id: CS3021,
     Severity: Warning,
     WarningLevel: 2,
-    Descriptor: {
-      Id: CS3021,
-      Title: Type or member does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS3021),
-      MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute,
-      Category: Compiler,
-      DefaultSeverity: Warning,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (10,22)-(10,31),
+    MessageFormat: '{0}' does not need a CLSCompliant attribute because the assembly does not have a CLSCompliant attribute
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes2/Avalonia/Tests.WithOtherAttributes2_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes2/Avalonia/Tests.WithOtherAttributes2_Diagnostics.verified.txt
@@ -1,26 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Avalonia;
-^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (0,0)-(0,15),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (1,1)-(1,16),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes2/Maui/Tests.WithOtherAttributes2_Diagnostics.verified.txt
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Snapshots/WithOtherAttributes2/Maui/Tests.WithOtherAttributes2_Diagnostics.verified.txt
@@ -1,27 +1,9 @@
 ﻿[
   {
-    Location: /*
-using Microsoft.Maui.Controls;
-using Microsoft.Maui;
-^^^^^^^^^^^^^^^^^^^^^
-using DependencyPropertyGenerator;
-*/
- : (1,0)-(1,21),
-    Message: Unnecessary using directive.,
+    Id: CS8019,
     Severity: Hidden,
     WarningLevel: 1,
-    Descriptor: {
-      Id: CS8019,
-      Title: Unnecessary using directive,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8019),
-      MessageFormat: Unnecessary using directive.,
-      Category: Compiler,
-      DefaultSeverity: Hidden,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry
-      ]
-    }
+    Span: (2,1)-(2,22),
+    MessageFormat: Unnecessary using directive.
   }
 ]

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Helpers.cs
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Helpers.cs
@@ -194,7 +194,7 @@ using DependencyPropertyGenerator;
         var diagnostics = compilation.GetDiagnostics(cancellationToken);
 
         await Task.WhenAll(
-            Verify(diagnostics.NormalizeLocations())
+            Verify(diagnostics.ToSnapshotModels())
                 .UseDirectory($"Snapshots/{callerName}/{framework:G}")
                 //.AutoVerify()
                 .UseTextForParameters("Diagnostics"),
@@ -247,6 +247,60 @@ using DependencyPropertyGenerator;
                 .Select(generatedSource => generatedSource.SourceText.ToString()));
     }
 }
+
+internal static class DiagnosticExtensions
+{
+    internal static IReadOnlyList<DiagnosticSnapshot> ToSnapshotModels(this IEnumerable<Diagnostic> diagnostics)
+    {
+        return diagnostics
+            .Select(static diagnostic => new DiagnosticSnapshot(
+                Id: diagnostic.Id,
+                Severity: diagnostic.Severity.ToString(),
+                WarningLevel: diagnostic.WarningLevel is 0 ? null : diagnostic.WarningLevel,
+                Location: GetLocation(diagnostic.Location),
+                Span: GetSpan(diagnostic.Location),
+                MessageFormat: diagnostic.Descriptor.MessageFormat.ToString()))
+            .ToArray();
+    }
+
+    private static string? GetLocation(Location location)
+    {
+        if (location is null or { IsInSource: false })
+        {
+            return null;
+        }
+
+        var path = location.GetLineSpan().Path;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        return path.Replace('/', '\\');
+    }
+
+    private static string? GetSpan(Location location)
+    {
+        if (location is null or { IsInSource: false })
+        {
+            return null;
+        }
+
+        var lineSpan = location.GetLineSpan();
+        var start = lineSpan.StartLinePosition;
+        var end = lineSpan.EndLinePosition;
+
+        return $"({start.Line + 1},{start.Character + 1})-({end.Line + 1},{end.Character + 1})";
+    }
+}
+
+internal sealed record DiagnosticSnapshot(
+    string Id,
+    string Severity,
+    int? WarningLevel,
+    string? Location,
+    string? Span,
+    string MessageFormat);
 
 internal static class StringExtensions
 {


### PR DESCRIPTION
## Summary

Follow-up to #156 after the Ubuntu PR check exposed environment-sensitive diagnostic snapshot output.

- Project compiler diagnostics into a small stable snapshot DTO instead of serializing Roslyn `Diagnostic` objects directly.
- Keep generated/source locations normalized while avoiding source-frame snippets and resolved diagnostic message text that differ across runners.
- Refresh the non-empty diagnostic snapshots to the stable format.

## Validation

- `dotnet test src\tests\DependencyPropertyGenerator.SnapshotTests\DependencyPropertyGenerator.SnapshotTests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test DependencyPropertyGenerator.sln --configuration Release --no-restore --logger "console;verbosity=minimal"`