### PR TITLE
Fix CS0436 warnings for generated attributes

### DIFF
--- a/src/libs/DependencyPropertyGenerator/Suppressors/Cs0436Suppressor.cs
+++ b/src/libs/DependencyPropertyGenerator/Suppressors/Cs0436Suppressor.cs
@@ -1,0 +1,40 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace H.Generators.Suppressors;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class Cs0436Suppressor : DiagnosticSuppressor
+{
+    private static readonly SuppressionDescriptor Descriptor = new(
+        id: "DPG0436",
+        suppressedDiagnosticId: "CS0436",
+        justification: "DependencyPropertyGenerator emits internal attribute helper types into each compilation; duplicate friend-assembly copies are expected.");
+
+    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions { get; } = ImmutableArray.Create(Descriptor);
+
+    public override void ReportSuppressions(SuppressionAnalysisContext context)
+    {
+        foreach (var diagnostic in context.ReportedDiagnostics)
+        {
+            if (ShouldSuppress(diagnostic))
+            {
+                context.ReportSuppression(Suppression.Create(Descriptor, diagnostic));
+            }
+        }
+    }
+
+    private static bool ShouldSuppress(Diagnostic diagnostic)
+    {
+        if (diagnostic.Id != "CS0436")
+        {
+            return false;
+        }
+
+        var message = diagnostic.GetMessage(System.Globalization.CultureInfo.InvariantCulture);
+
+        return message.Contains(@"DependencyPropertyGenerator\H.Generators.", StringComparison.Ordinal) ||
+               message.Contains("DependencyPropertyGenerator/H.Generators.", StringComparison.Ordinal);
+    }
+}

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.RoutedEvents.cs
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.RoutedEvents.cs
@@ -86,4 +86,120 @@ public partial class MyControl : UserControl
         generated.Should().NotContain("global::global::");
         generated.Should().Contain("global::H.Generators.IntegrationTests.MyRoutedEventHandler");
     }
+
+    [TestMethod]
+    public async Task Cs0436Suppressor_SuppressesOnlyGeneratedAttributeConflicts()
+    {
+        var parseOptions = global::Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Default
+            .WithLanguageVersion(global::Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview);
+        var references = (await global::Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net48.Wpf.ResolveAsync(null, CancellationToken.None))
+            .ToArray();
+
+        var projectA = CreateCompilation(
+            assemblyName: "ProjectA",
+            source: @"
+using System.Runtime.CompilerServices;
+using DependencyPropertyGenerator;
+using System.Windows.Controls;
+
+[assembly: InternalsVisibleTo(""ProjectB"")]
+
+namespace ProjectA;
+
+internal sealed class SharedType
+{
+}
+
+[RoutedEvent(""Opened"", RoutedEventStrategy.Bubble)]
+internal partial class ProjectAControl : Control
+{
+}",
+            references,
+            parseOptions);
+        projectA = RunRoutedEventGenerator(projectA, parseOptions);
+
+        using var projectAAssembly = new MemoryStream();
+        var projectAEmitResult = projectA.Emit(projectAAssembly);
+        projectAEmitResult.Success.Should().BeTrue(string.Join(Environment.NewLine, projectAEmitResult.Diagnostics));
+        projectAAssembly.Position = 0;
+
+        var projectB = CreateCompilation(
+            assemblyName: "ProjectB",
+            source: @"
+using DependencyPropertyGenerator;
+using System.Windows.Controls;
+
+namespace ProjectA
+{
+    internal sealed class SharedType
+    {
+    }
+}
+
+namespace ProjectB
+{
+    [RoutedEvent(""Closed"", RoutedEventStrategy.Bubble)]
+    internal partial class ProjectBControl : Control
+    {
+        private ProjectA.SharedType? SharedType { get; set; }
+    }
+}",
+            references.Concat(new[] { global::Microsoft.CodeAnalysis.MetadataReference.CreateFromStream(projectAAssembly) }).ToArray(),
+            parseOptions);
+        projectB = RunRoutedEventGenerator(projectB, parseOptions);
+
+        var rawCs0436Diagnostics = projectB.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Id == "CS0436")
+            .ToArray();
+        rawCs0436Diagnostics.Should().Contain(static diagnostic =>
+            diagnostic.GetMessage().Contains("RoutedEventAttribute", StringComparison.Ordinal));
+        rawCs0436Diagnostics.Should().Contain(static diagnostic =>
+            diagnostic.GetMessage().Contains("SharedType", StringComparison.Ordinal));
+
+        var diagnostics = await global::Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzerExtensions
+            .WithAnalyzers(
+                projectB,
+                global::System.Collections.Immutable.ImmutableArray.Create<global::Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer>(
+                    new global::H.Generators.Suppressors.Cs0436Suppressor()),
+                new global::Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions(
+                    global::System.Collections.Immutable.ImmutableArray<global::Microsoft.CodeAnalysis.AdditionalText>.Empty))
+            .GetAllDiagnosticsAsync();
+
+        diagnostics.Where(static diagnostic => diagnostic.Id == "CS0436")
+            .Should()
+            .ContainSingle(static diagnostic => diagnostic.GetMessage().Contains("SharedType", StringComparison.Ordinal));
+        diagnostics.Where(static diagnostic => diagnostic.Severity == global::Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+    }
+
+    private static global::Microsoft.CodeAnalysis.Compilation CreateCompilation(
+        string assemblyName,
+        string source,
+        global::Microsoft.CodeAnalysis.MetadataReference[] references,
+        global::Microsoft.CodeAnalysis.CSharp.CSharpParseOptions parseOptions)
+    {
+        return global::Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            syntaxTrees: new[]
+            {
+                global::Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source, options: parseOptions),
+            },
+            references: references,
+            options: new global::Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(global::Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static global::Microsoft.CodeAnalysis.Compilation RunRoutedEventGenerator(
+        global::Microsoft.CodeAnalysis.Compilation compilation,
+        global::Microsoft.CodeAnalysis.CSharp.CSharpParseOptions parseOptions)
+    {
+        global::Microsoft.CodeAnalysis.GeneratorDriver driver = global::Microsoft.CodeAnalysis.CSharp.CSharpGeneratorDriver.Create(
+            generators: new[] { global::Microsoft.CodeAnalysis.GeneratorExtensions.AsSourceGenerator(new RoutedEventGenerator()) },
+            parseOptions: parseOptions);
+        driver = driver
+            .WithUpdatedAnalyzerConfigOptions(new global::H.Generators.Tests.Extensions.DictionaryAnalyzerConfigOptionsProvider(GetGlobalOptions(Framework.Wpf)))
+            .RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out _);
+
+        return updatedCompilation;
+    }
 }


### PR DESCRIPTION
## Summary

- suppress only CS0436 conflicts caused by DependencyPropertyGenerator's injected internal helper types
- preserve unrelated CS0436 diagnostics
- add an InternalsVisibleTo regression test

## Root cause

Each compilation receives its own internal attribute helper types. InternalsVisibleTo makes an upstream project's generated copies visible to a downstream project, so Roslyn reports expected local-vs-imported CS0436 conflicts.

## Validation

- dotnet test DependencyPropertyGenerator.sln --no-restore
- Release package consumer build with two WPF projects and InternalsVisibleTo: 0 warnings, 0 errors

Closes #159