### PR TITLE
Fix framework detection during self-contained publish

### DIFF
--- a/src/libs/DependencyPropertyGenerator/Extensions/FrameworkDetectionExtensions.cs
+++ b/src/libs/DependencyPropertyGenerator/Extensions/FrameworkDetectionExtensions.cs
@@ -1,0 +1,84 @@
+using H.Generators.Extensions;
+using Microsoft.CodeAnalysis;
+
+namespace H.Generators;
+
+internal static class FrameworkDetectionExtensions
+{
+#pragma warning disable RS1032, RS2008
+    private static readonly DiagnosticDescriptor FrameworkNotRecognized = new(
+        id: "TRF001",
+        title: "Framework is not recognized",
+        messageFormat: AnalyzerConfigOptionsProviderExtensions.FrameworkIsNotRecognized,
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+#pragma warning restore RS1032, RS2008
+
+    public static IncrementalValueProvider<Framework> DetectFrameworkFromOptionsOrReferences(
+        this IncrementalGeneratorInitializationContext context)
+    {
+        var frameworkWithDiagnostic = context.AnalyzerConfigOptionsProvider
+            .Combine(context.CompilationProvider)
+            .Select(static (tuple, _) =>
+            {
+                var framework = tuple.Left.TryRecognizeFramework();
+                if (framework == Framework.None)
+                {
+                    framework = InferFramework(tuple.Right);
+                }
+
+                var diagnostic = framework == Framework.None
+                    ? Diagnostic.Create(FrameworkNotRecognized, Location.None)
+                    : null;
+
+                return (Framework: framework, Diagnostic: diagnostic);
+            });
+
+        context.RegisterSourceOutput(
+            frameworkWithDiagnostic,
+            static (sourceProductionContext, tuple) =>
+            {
+                if (tuple.Diagnostic is { } diagnostic)
+                {
+                    sourceProductionContext.ReportDiagnostic(diagnostic);
+                }
+            });
+
+        return frameworkWithDiagnostic.Select(static (tuple, _) => tuple.Framework);
+    }
+
+    private static Framework InferFramework(Compilation compilation)
+    {
+        if (compilation.GetTypeByMetadataName("Microsoft.Maui.Controls.BindableObject") is not null)
+        {
+            return Framework.Maui;
+        }
+
+        if (compilation.GetTypeByMetadataName("Avalonia.AvaloniaObject") is not null)
+        {
+            return Framework.Avalonia;
+        }
+
+        var isUno = compilation.ReferencedAssemblyNames.Any(static assembly =>
+            assembly.Name.StartsWith("Uno.UI", StringComparison.OrdinalIgnoreCase) ||
+            assembly.Name.StartsWith("Uno.WinUI", StringComparison.OrdinalIgnoreCase));
+
+        if (compilation.GetTypeByMetadataName("Microsoft.UI.Xaml.DependencyObject") is not null)
+        {
+            return isUno ? Framework.UnoWinUi : Framework.WinUi;
+        }
+
+        if (compilation.GetTypeByMetadataName("Windows.UI.Xaml.DependencyObject") is not null)
+        {
+            return isUno ? Framework.Uno : Framework.Uwp;
+        }
+
+        if (compilation.GetTypeByMetadataName("System.Windows.DependencyObject") is not null)
+        {
+            return Framework.Wpf;
+        }
+
+        return Framework.None;
+    }
+}

--- a/src/libs/DependencyPropertyGenerator/Generators/AddOwnerGenerator.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/AddOwnerGenerator.cs
@@ -23,7 +23,7 @@ public class AddOwnerGenerator : IIncrementalGenerator
                 source: Resources.AddOwnerAttribute_cs.AsString());
         });
 
-        var framework = context.DetectFramework();
+        var framework = context.DetectFrameworkFromOptionsOrReferences();
         var version = context.DetectVersion();
 
         context.SyntaxProvider

--- a/src/libs/DependencyPropertyGenerator/Generators/AttachedDependencyPropertyGenerator.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/AttachedDependencyPropertyGenerator.cs
@@ -23,7 +23,7 @@ public class AttachedDependencyPropertyGenerator : IIncrementalGenerator
                 source: Resources.AttachedDependencyPropertyAttribute_cs.AsString());
         });
 
-        var framework = context.DetectFramework();
+        var framework = context.DetectFrameworkFromOptionsOrReferences();
         var version = context.DetectVersion();
 
         context.SyntaxProvider

--- a/src/libs/DependencyPropertyGenerator/Generators/DependencyPropertyGenerator.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/DependencyPropertyGenerator.cs
@@ -23,7 +23,7 @@ public class DependencyPropertyGenerator : IIncrementalGenerator
                 source: Resources.DependencyPropertyAttribute_cs.AsString());
         });
 
-        var framework = context.DetectFramework();
+        var framework = context.DetectFrameworkFromOptionsOrReferences();
         var version = context.DetectVersion();
 
         context.SyntaxProvider

--- a/src/libs/DependencyPropertyGenerator/Generators/OverrideMetadataGenerator.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/OverrideMetadataGenerator.cs
@@ -24,7 +24,7 @@ public class OverrideMetadataGenerator : IIncrementalGenerator
                 source: Resources.OverrideMetadataAttribute_cs.AsString());
         });
 
-        var framework = context.DetectFramework();
+        var framework = context.DetectFrameworkFromOptionsOrReferences();
         var version = context.DetectVersion();
 
         context.SyntaxProvider

--- a/src/libs/DependencyPropertyGenerator/Generators/RoutedEventGenerator.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/RoutedEventGenerator.cs
@@ -26,7 +26,7 @@ public class RoutedEventGenerator : IIncrementalGenerator
                 source: Resources.RoutedEventStrategy_cs.AsString());
         });
 
-        var framework = context.DetectFramework();
+        var framework = context.DetectFrameworkFromOptionsOrReferences();
         var version = context.DetectVersion();
 
         context.SyntaxProvider

--- a/src/libs/DependencyPropertyGenerator/Generators/StaticConstructorGenerator.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/StaticConstructorGenerator.cs
@@ -30,7 +30,7 @@ public class StaticConstructorGenerator : IIncrementalGenerator
                 source: Resources.SourceTrigger_cs.AsString());
         });
 
-        var framework = context.DetectFramework();
+        var framework = context.DetectFrameworkFromOptionsOrReferences();
         var version = context.DetectVersion();
 
         var dp1 = context.SyntaxProvider

--- a/src/libs/DependencyPropertyGenerator/Generators/WeakEventGenerator.cs
+++ b/src/libs/DependencyPropertyGenerator/Generators/WeakEventGenerator.cs
@@ -23,7 +23,7 @@ public class WeakEventGenerator : IIncrementalGenerator
                 source: Resources.WeakEventAttribute_cs.AsString());
         });
 
-        var framework = context.DetectFramework();
+        var framework = context.DetectFrameworkFromOptionsOrReferences();
         var version = context.DetectVersion();
 
         context.SyntaxProvider

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Errors.cs
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Errors.cs
@@ -2,13 +2,55 @@
 
 public partial class Tests
 {
+    [TestMethod]
+    public async Task FrameworkIsInferredFromReferencesWhenAnalyzerOptionsAreMissing()
+    {
+        var parseOptions = global::Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.Default
+            .WithLanguageVersion(global::Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview);
+        var references = (await global::Microsoft.CodeAnalysis.Testing.ReferenceAssemblies.NetFramework.Net48.Wpf.ResolveAsync(null, CancellationToken.None))
+            .ToArray();
+        var compilation = CreateCompilation(
+            assemblyName: "SelfContainedPublish",
+            source: @"
+using DependencyPropertyGenerator;
+using System.Windows.Controls;
+
+namespace SelfContainedPublish;
+
+[DependencyProperty<int>(""Value"")]
+internal partial class GeneratedControl : Control
+{
+}",
+            references,
+            parseOptions);
+
+        global::Microsoft.CodeAnalysis.GeneratorDriver driver = global::Microsoft.CodeAnalysis.CSharp.CSharpGeneratorDriver.Create(
+            generators: new global::Microsoft.CodeAnalysis.IIncrementalGenerator[]
+            {
+                new DependencyPropertyGenerator(),
+                new StaticConstructorGenerator(),
+            }.Select(global::Microsoft.CodeAnalysis.GeneratorExtensions.AsSourceGenerator),
+            parseOptions: parseOptions);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out _);
+
+        var diagnostics = updatedCompilation.GetDiagnostics();
+        diagnostics.Should().NotContain(static diagnostic =>
+            diagnostic.Id == "TRF001" || diagnostic.Id == "DPG" || diagnostic.Id == "ADPG");
+        diagnostics.Where(static diagnostic => diagnostic.Severity == global::Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .Should()
+            .BeEmpty();
+        driver.GetRunResult().GeneratedTrees
+            .Should()
+            .Contain(static tree => tree.FilePath.Contains("GeneratedControl.Properties.Value.g.cs", StringComparison.Ordinal));
+    }
+
     [DataTestMethod]
     [DataRow(Framework.None)]
     public Task NoneFramework(Framework framework)
     {
-        return CheckSourceAsync<WeakEventGenerator>(GetHeader(framework, "Controls") + @"
+        return CheckSourceAsync<WeakEventGenerator>(GetHeader(framework) + @"
 [WeakEvent<string>(""UrlChanged"", IsStatic = true)]
-public partial class MyControl : UserControl
+public partial class MyControl
 {
 }", framework);
     }

--- a/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Helpers.cs
+++ b/src/tests/DependencyPropertyGenerator.SnapshotTests/Tests.Helpers.cs
@@ -150,7 +150,7 @@ using DependencyPropertyGenerator;
 
         var referenceAssemblies = framework switch
         {
-            Framework.None => ReferenceAssemblies.NetFramework.Net48.Wpf,
+            Framework.None => ReferenceAssemblies.NetFramework.Net48.Default,
             Framework.Wpf => ReferenceAssemblies.NetFramework.Net48.Wpf,
             Framework.Uwp => FrameworkReferenceAssemblies.Net80Uwp,
             Framework.WinUi => FrameworkReferenceAssemblies.Net80WinUi,
@@ -213,7 +213,7 @@ using DependencyPropertyGenerator;
         source = ApplyFrameworkReplacements(source, framework);
         var referenceAssemblies = framework switch
         {
-            Framework.None => ReferenceAssemblies.NetFramework.Net48.Wpf,
+            Framework.None => ReferenceAssemblies.NetFramework.Net48.Default,
             Framework.Wpf => ReferenceAssemblies.NetFramework.Net48.Wpf,
             Framework.Uwp => FrameworkReferenceAssemblies.Net80Uwp,
             Framework.WinUi => FrameworkReferenceAssemblies.Net80WinUi,


### PR DESCRIPTION
## Summary

- keep explicit MSBuild framework settings authoritative
- infer the UI framework from compilation references when publish-time analyzer options are missing
- cover WPF inference and preserve the unknown-framework diagnostic

## Root cause

Framework detection relied entirely on analyzer-config MSBuild properties. Some self-contained publish paths can invoke compilation without those values, causing TRF001 and generator exceptions even though the required UI framework assemblies are referenced.

## Validation

- `dotnet test DependencyPropertyGenerator.sln --no-restore` (239 snapshot tests, 1 integration test)
- packaged `1.5.2-beta.2` WPF self-contained publish with `RecognizeFramework_DefineConstants` and `UseWPF` blank: succeeded

Fixes #67